### PR TITLE
Add Options

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,15 @@ if let subject = greeting.match("hello swift")?.captures[0] {
 }
 ```
 
+Options:
+
+```swift
+let totallyUniqueExamples = Regex("^(hello|foo).*$", options: [.IgnoreCase, .AnchorsMatchLines])
+let multilineText = "hello world\ngoodbye world\nFOOBAR\n"
+let matchingLines = totallyUniqueExamples.allMatches(multilineText).map { $0.matchedString }
+// ["hello world", "FOOBAR"]
+```
+
 
 
 ## Installation

--- a/Regex.xcodeproj/project.pbxproj
+++ b/Regex.xcodeproj/project.pbxproj
@@ -15,6 +15,10 @@
 		CE322FB91C165238005741D5 /* Quick.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE322FAC1C1651D5005741D5 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE322FBB1C16525F005741D5 /* Nimble.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE322FA91C1651D5005741D5 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		CE322FBC1C16525F005741D5 /* Quick.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = CE322FAA1C1651D5005741D5 /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		CE4BE2941C168183005E4D4F /* OptionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE322FBD1C168146005741D5 /* OptionsSpec.swift */; };
+		CE4BE2951C168183005E4D4F /* OptionsSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE322FBD1C168146005741D5 /* OptionsSpec.swift */; };
+		CE4BE2971C1682CF005E4D4F /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4BE2961C1682CF005E4D4F /* Options.swift */; };
+		CE4BE2981C168507005E4D4F /* Options.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE4BE2961C1682CF005E4D4F /* Options.swift */; };
 		CE6CDF641BE239DE00AE6393 /* Regex.h in Headers */ = {isa = PBXBuildFile; fileRef = CE6CDF631BE239DE00AE6393 /* Regex.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CE6CDF6B1BE239DE00AE6393 /* Regex.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CE6CDF601BE239DE00AE6393 /* Regex.framework */; };
 		CE6CDF701BE239DE00AE6393 /* RegexSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE6CDF6F1BE239DE00AE6393 /* RegexSpec.swift */; };
@@ -78,6 +82,8 @@
 		CE322FAA1C1651D5005741D5 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		CE322FAB1C1651D5005741D5 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
 		CE322FAC1C1651D5005741D5 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
+		CE322FBD1C168146005741D5 /* OptionsSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OptionsSpec.swift; sourceTree = "<group>"; };
+		CE4BE2961C1682CF005E4D4F /* Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		CE6CDF601BE239DE00AE6393 /* Regex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Regex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		CE6CDF631BE239DE00AE6393 /* Regex.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Regex.h; sourceTree = "<group>"; };
 		CE6CDF651BE239DE00AE6393 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -155,6 +161,7 @@
 			children = (
 				CE6CDF811BE23BE800AE6393 /* Regex.swift */,
 				CE6CDF831BE2C52600AE6393 /* MatchResult.swift */,
+				CE4BE2961C1682CF005E4D4F /* Options.swift */,
 				CE6CDF851BE2C64D00AE6393 /* Foundation+Ranges.swift */,
 				CE6CDF7A1BE23A1D00AE6393 /* Supporting Files */,
 			);
@@ -165,6 +172,7 @@
 			isa = PBXGroup;
 			children = (
 				CE6CDF6F1BE239DE00AE6393 /* RegexSpec.swift */,
+				CE322FBD1C168146005741D5 /* OptionsSpec.swift */,
 				CE6CDF7B1BE23A2E00AE6393 /* Supporting Files */,
 			);
 			path = Tests;
@@ -374,6 +382,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE4BE2971C1682CF005E4D4F /* Options.swift in Sources */,
 				CE6CDF841BE2C52600AE6393 /* MatchResult.swift in Sources */,
 				CE6CDF821BE23BE800AE6393 /* Regex.swift in Sources */,
 				CE6CDF861BE2C64D00AE6393 /* Foundation+Ranges.swift in Sources */,
@@ -385,6 +394,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE6CDF701BE239DE00AE6393 /* RegexSpec.swift in Sources */,
+				CE4BE2941C168183005E4D4F /* OptionsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -392,6 +402,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CE4BE2981C168507005E4D4F /* Options.swift in Sources */,
 				CEC768801BE99B690066BA1E /* Regex.swift in Sources */,
 				CEC768811BE99B690066BA1E /* MatchResult.swift in Sources */,
 				CEC768821BE99B690066BA1E /* Foundation+Ranges.swift in Sources */,
@@ -403,6 +414,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CEC768841BE99B7C0066BA1E /* RegexSpec.swift in Sources */,
+				CE4BE2951C168183005E4D4F /* OptionsSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -1,7 +1,29 @@
+/// `Options` defines alternate behaviours of regular expressions when matching.
 public struct Options: OptionSetType {
 
+  /// Ignores the case of letters when matching.
+  ///
+  /// Example:
+  ///
+  ///     let a = Regex("a", options: .IgnoreCase)
+  ///     a.allMatches("aA").map { $0.matchedString } // ["a", "A"]
   public static let IgnoreCase = Options(rawValue: 1)
+
+  /// Ignore any metacharacters in the pattern, treating every character as
+  /// a literal.
+  ///
+  /// Example:
+  ///
+  ///     let parens = Regex("()", options: .IgnoreMetacharacters)
+  ///     parens.matches("()") // true
   public static let IgnoreMetacharacters = Options(rawValue: 1 << 1)
+
+  /// By default, "^" matches the beginning of the string and "$" matches the
+  /// end of the string, ignoring any newlines. With this option, "^" will
+  /// the beginning of each line, and "$" will match the end of each line.
+  ///
+  ///     let foo = Regex("^foo", options: .AnchorsMatchLines)
+  ///     foo.allMatches("foo\nbar\nfoo\n").count // 2
   public static let AnchorsMatchLines = Options(rawValue: 1 << 2)
 
   // MARK: OptionSetType
@@ -16,6 +38,7 @@ public struct Options: OptionSetType {
 
 internal extension Options {
 
+  /// Transform an instance of `Regex.Options` into the equivalent `NSRegularExpressionOptions`.
   func toNSRegularExpressionOptions() -> NSRegularExpressionOptions {
     var options = NSRegularExpressionOptions()
     if contains(.IgnoreCase) { options.insert(.CaseInsensitive) }

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -1,0 +1,23 @@
+public struct Options: OptionSetType {
+
+  public static let IgnoreCase = Options(rawValue: 1)
+
+  // MARK: OptionSetType
+
+  public let rawValue: Int
+
+  public init(rawValue: Int) {
+    self.rawValue = rawValue
+  }
+
+}
+
+internal extension Options {
+
+  func toNSRegularExpressionOptions() -> NSRegularExpressionOptions {
+    var options = NSRegularExpressionOptions()
+    if contains(.IgnoreCase) { options.insert(.CaseInsensitive) }
+    return options
+  }
+
+}

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -1,6 +1,7 @@
 public struct Options: OptionSetType {
 
   public static let IgnoreCase = Options(rawValue: 1)
+  public static let IgnoreMetacharacters = Options(rawValue: 1 << 1)
 
   // MARK: OptionSetType
 
@@ -17,6 +18,7 @@ internal extension Options {
   func toNSRegularExpressionOptions() -> NSRegularExpressionOptions {
     var options = NSRegularExpressionOptions()
     if contains(.IgnoreCase) { options.insert(.CaseInsensitive) }
+    if contains(.IgnoreMetacharacters) { options.insert(.IgnoreMetacharacters) }
     return options
   }
 

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -2,6 +2,7 @@ public struct Options: OptionSetType {
 
   public static let IgnoreCase = Options(rawValue: 1)
   public static let IgnoreMetacharacters = Options(rawValue: 1 << 1)
+  public static let AnchorsMatchLines = Options(rawValue: 1 << 2)
 
   // MARK: OptionSetType
 
@@ -19,6 +20,7 @@ internal extension Options {
     var options = NSRegularExpressionOptions()
     if contains(.IgnoreCase) { options.insert(.CaseInsensitive) }
     if contains(.IgnoreMetacharacters) { options.insert(.IgnoreMetacharacters) }
+    if contains(.AnchorsMatchLines) { options.insert(.AnchorsMatchLines) }
     return options
   }
 

--- a/Source/Regex.swift
+++ b/Source/Regex.swift
@@ -4,8 +4,8 @@ public struct Regex: StringLiteralConvertible, CustomStringConvertible, CustomDe
 
   private let regex: NSRegularExpression
 
-  public init(_ pattern: String) {
-    regex = try! NSRegularExpression(pattern: pattern, options: [])
+  public init(_ pattern: String, options: Options = []) {
+    regex = try! NSRegularExpression(pattern: pattern, options: options.toNSRegularExpressionOptions())
   }
 
   public init(stringLiteral value: String) {

--- a/Tests/OptionsSpec.swift
+++ b/Tests/OptionsSpec.swift
@@ -21,6 +21,14 @@ final class OptionsSpec: QuickSpec {
       }
     }
 
+    describe(".AnchorsMatchLines") {
+      it("can anchor matches to the start of each line") {
+        let regex = Regex("^foo", options: .AnchorsMatchLines)
+        let multilineString = "foo\nbar\nfoo\nbaz"
+        expect(regex.allMatches(multilineString).count).to(equal(2))
+      }
+    }
+
   }
 }
 

--- a/Tests/OptionsSpec.swift
+++ b/Tests/OptionsSpec.swift
@@ -1,0 +1,21 @@
+final class OptionsSpec: QuickSpec {
+  override func spec() {
+
+    describe(".IgnoreCase") {
+      it("enables an uppercase pattern to match lowercase input") {
+        let regex = Regex("FOO", options: .IgnoreCase)
+        expect(regex.matches("foo")).to(beTrue())
+      }
+
+      it("enables a lowercase pattern to match uppercase input") {
+        let regex = Regex("foo", options: .IgnoreCase)
+        expect(regex.matches("FOO")).to(beTrue())
+      }
+    }
+
+  }
+}
+
+import Quick
+import Nimble
+import Regex

--- a/Tests/OptionsSpec.swift
+++ b/Tests/OptionsSpec.swift
@@ -13,6 +13,14 @@ final class OptionsSpec: QuickSpec {
       }
     }
 
+    describe(".IgnoreMetacharacters") {
+      it("treats metacharacters as literals") {
+        let regex = Regex("foo(bar)", options: .IgnoreMetacharacters)
+        expect(regex.matches("foobar")).to(beFalse())
+        expect(regex.matches("foo(bar)")).to(beTrue())
+      }
+    }
+
   }
 }
 

--- a/Tests/RegexSpec.swift
+++ b/Tests/RegexSpec.swift
@@ -87,6 +87,13 @@ final class RegexSpec: QuickSpec {
         let multilineString = "foo\nbar\nfoo\nbaz"
         expect(regex.allMatches(multilineString).count).to(equal(2))
       }
+
+      it("validates that the example in the README is correct") {
+        let totallyUniqueExamples = Regex("^(hello|foo).*$", options: [.IgnoreCase, .AnchorsMatchLines])
+        let multilineText = "hello world\ngoodbye world\nFOOBAR\n"
+        let matchingLines = totallyUniqueExamples.allMatches(multilineText).map { $0.matchedString }
+        expect(matchingLines).to(equal(["hello world", "FOOBAR"]))
+      }
     }
 
   }

--- a/Tests/RegexSpec.swift
+++ b/Tests/RegexSpec.swift
@@ -81,6 +81,14 @@ final class RegexSpec: QuickSpec {
       }
     }
 
+    describe("matching at line anchors") {
+      it("can anchor matches to the start of each line") {
+        let regex = Regex("(?m)^foo")
+        let multilineString = "foo\nbar\nfoo\nbaz"
+        expect(regex.allMatches(multilineString).count).to(equal(2))
+      }
+    }
+
   }
 }
 


### PR DESCRIPTION
- Adds a new `Regex.Options` option set type.
- Adds a new, optional `options:` parameter to `Regex.init()`.
- Adds support for the `Ignore`, `IgnoreMetacharacters` and `AnchorsMatchLines` options.

Fixes #3.

To do:
- [x] Update the README
