### PR TITLE
Specify Regex's module name to CocoaPods

### DIFF
--- a/STRegex.podspec
+++ b/STRegex.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author       = "Adam Sharp"
   s.source       = { :git => "https://github.com/sharplet/Regex.git", :tag => s.version.to_s }
   s.source_files = "Source/**/*.swift"
+  s.module_name  = "Regex"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.9"
 end


### PR DESCRIPTION
The pod name is `STRegex`, but you should be able to `import Regex` in your Swift code.
