### PR TITLE
Fix crash occurring when a capture group is optional and isn't matched

### DIFF
--- a/Source/MatchResult.swift
+++ b/Source/MatchResult.swift
@@ -4,7 +4,7 @@ public struct MatchResult {
 
   // MARK: Accessing match results
 
-  public var captures: [String] {
+  public var captures: [String?] {
     return _result.captures
   }
 
@@ -33,19 +33,20 @@ private final class _MatchResult {
     self.result = result
   }
 
-  lazy var captures: [String] = {
-    return self.captureRanges.map(self.substringFromRange)
+  lazy var captures: [String?] = {
+    return self.captureRanges.map { $0.map(self.substringFromRange) }
   }()
 
-  lazy var captureRanges: [Range<String.UTF16Index>] = {
+  lazy var captureRanges: [Range<String.UTF16Index>?] = {
     return self.result.ranges.dropFirst().map(self.rangeFromNSRange)
   }()
 
   lazy var matchedString: String = {
-    return self.substringFromRange(self.rangeFromNSRange(self.result.range))
+    return self.substringFromRange(self.rangeFromNSRange(self.result.range)!)
   }()
 
-  private func rangeFromNSRange(range: NSRange) -> Range<String.UTF16Index> {
+  private func rangeFromNSRange(range: NSRange) -> Range<String.UTF16Index>? {
+    guard range.location != NSNotFound else { return nil }
     let start = string.startIndex.advancedBy(range.location)
     let end = start.advancedBy(range.length)
     return start..<end

--- a/Source/MatchResult.swift
+++ b/Source/MatchResult.swift
@@ -1,15 +1,45 @@
 import Foundation
 
+/// A `MatchResult` encapsulates the result of a single match in a string,
+/// providing access to the matched string, as well as any capture groups within
+/// that string.
 public struct MatchResult {
 
   // MARK: Accessing match results
 
-  public var captures: [String?] {
-    return _result.captures
-  }
-
+  /// The entire matched string.
+  ///
+  /// Example:
+  ///
+  ///     let pattern = Regex("a*")
+  ///
+  ///     if let match = pattern.match("aaa") {
+  ///       match.matchedString // "aaa"
+  ///     }
+  ///
+  ///     if let match = pattern.match("bbb") {
+  ///       match.matchedString // ""
+  ///     }
   public var matchedString: String {
     return _result.matchedString
+  }
+
+  /// The matching string for each capture group in the regular expression
+  /// (if any).
+  ///
+  /// **Note:** Usually if the match was successful, the captures will by
+  /// definition be non-nil. However if a given capture group is optional, the
+  /// captured string may also be nil, depending on the particular string that
+  /// is being matched against.
+  ///
+  /// Example:
+  ///
+  ///     let regex = Regex("(a)?(b)")
+  ///
+  ///     regex.match("ab")?.captures // [Optional("a"), Optional("b")]
+  ///     regex.match("b")?.captures // [nil, Optional("b")]
+  public var captures: [String?] {
+    return _result.captures
   }
 
   // MARK: Internal initialisers


### PR DESCRIPTION
When an optional capture group is specified (e.g., `(a)?`), and as a result doesn't match, the location of the range at that index is `NSNotFound`. Attempting to build a `Range<String.UTF16Index>` would then result in an out of bounds error and crash (because `NSNotFound` is a very large number).

This is a breaking change on the type of `MatchResult.captures` (`[String]` => `[String?]`). This change could theoretically be made non-breaking by using the type `[String!]` to allow for convenient access for the arguably more common case of non-optional capture groups. This would force the user to explicitly use optional binding in order to restore safety. However this is not advisable, as this kind of crash is likely to be surprising. For that reason this change opts for safety.

Usually the code that accesses capture results will be close to the code that constructs the regular expression, e.g.:

``` swift
let regex = Regex("Hello, (\\w+)")

if let match = regex.match("Hello, world") {
  let subject = match.captures[0]!
  print("Greeted \(subject)")
}
```

Here we can clearly see that there is a single capture group, and it is non-optional. So just as we can assume that it is safe to access `captures[0]`, we can also safely use the force unwrapping operator to
extract the captured string.

To do:
- [x] Documentation for the `MatchResult.captures` property explaining why captures are optional.
