### PR TITLE
Remove StringLiteralConvertible conformance

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,6 @@ Create:
 
 ```swift
 let greeting = Regex("hello (world|universe)")
-
-let magic: Regex = "(.*)"
 ```
 
 Match:
@@ -36,7 +34,7 @@ default:
 Capture:
 
 ```swift
-let greeting: Regex = "hello (world|universe|swift)"
+let greeting = Regex("hello (world|universe|swift)")
 
 if let subject = greeting.match("hello swift")?.captures[0] {
   print("ohai \(subject)")

--- a/Source/Regex.swift
+++ b/Source/Regex.swift
@@ -1,5 +1,4 @@
-// swiftlint:disable:next line_length
-public struct Regex: StringLiteralConvertible, CustomStringConvertible, CustomDebugStringConvertible {
+public struct Regex: CustomStringConvertible, CustomDebugStringConvertible {
 
   // MARK: Initialisation
 
@@ -23,18 +22,6 @@ public struct Regex: StringLiteralConvertible, CustomStringConvertible, CustomDe
     } catch {
       fatalError("expected a valid regex: \(error)")
     }
-  }
-
-  public init(stringLiteral value: String) {
-    self.init(value)
-  }
-
-  public init(extendedGraphemeClusterLiteral value: String) {
-    self.init(value)
-  }
-
-  public init(unicodeScalarLiteral value: String) {
-    self.init(value)
   }
 
   // MARK: Matching

--- a/Tests/RegexSpec.swift
+++ b/Tests/RegexSpec.swift
@@ -2,11 +2,6 @@ final class RegexSpec: QuickSpec {
   override func spec() {
 
     describe("Regex") {
-      it("is string literal convertible") {
-        let regex: Regex = "foo"
-        expect(regex).notTo(beNil())
-      }
-
       it("matches with no capture groups") {
         let regex = Regex("now you're matching with regex")
         expect(regex).to(match("now you're matching with regex"))


### PR DESCRIPTION
As discussed in #21, `StringLiteralConvertible` does seem like a really nice addition, however there are potentially surprising and unsafe drawbacks.

For background, initially I wanted this feature for an API that could accept either string literals or concrete `Regex`. For other reasons I ended up going down the route of overloading the function instead. This also worked well for #31. I feel this strikes a better balance between safety and convenience. It also results in APIs that are more discoverable, more learnable and less magical.
