### PR TITLE
Added DotMatchesLineSeparators and updated Quick version

### DIFF
--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "Quick/Nimble" "v3.0.0"
-github "Quick/Quick" "v0.8.0"
+github "Quick/Nimble" "v4.0.1"
+github "Quick/Quick" "v0.9.2"

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -25,6 +25,10 @@ public struct Options: OptionSetType {
   ///     let foo = Regex("^foo", options: .AnchorsMatchLines)
   ///     foo.allMatches("foo\nbar\nfoo\n").count // 2
   public static let AnchorsMatchLines = Options(rawValue: 1 << 2)
+	
+  /// Usually, "." matches all characters except newlines (\n). Using this
+  /// this options will allow "." to match newLines
+  public static let DotMatchesLineSeparators = Options(rawValue: 1 << 3)
 
   // MARK: OptionSetType
 
@@ -46,6 +50,7 @@ internal extension Options {
     if contains(.IgnoreCase) { options.insert(.CaseInsensitive) }
     if contains(.IgnoreMetacharacters) { options.insert(.IgnoreMetacharacters) }
     if contains(.AnchorsMatchLines) { options.insert(.AnchorsMatchLines) }
+	if contains(.DotMatchesLineSeparators) { options.insert(.DotMatchesLineSeparators) }
     return options
   }
 

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -28,6 +28,9 @@ public struct Options: OptionSetType {
 	
   /// Usually, "." matches all characters except newlines (\n). Using this
   /// this options will allow "." to match newLines
+  ///
+  ///     let newLines = Regex("test.test", options: .DotMatchesLineSeparators)
+  ///     newLines.allMatches(multilineString).count // 1
   public static let DotMatchesLineSeparators = Options(rawValue: 1 << 3)
 
   // MARK: OptionSetType

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -30,7 +30,7 @@ public struct Options: OptionSetType {
   /// this options will allow "." to match newLines
   ///
   ///     let newLines = Regex("test.test", options: .DotMatchesLineSeparators)
-  ///     newLines.allMatches(multilineString).count // 1
+  ///     newLines.allMatches("test\ntest").count // 1
   public static let DotMatchesLineSeparators = Options(rawValue: 1 << 3)
 
   // MARK: OptionSetType

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -25,7 +25,7 @@ public struct Options: OptionSetType {
   ///     let foo = Regex("^foo", options: .AnchorsMatchLines)
   ///     foo.allMatches("foo\nbar\nfoo\n").count // 2
   public static let AnchorsMatchLines = Options(rawValue: 1 << 2)
-	
+
   /// Usually, "." matches all characters except newlines (\n). Using this
   /// this options will allow "." to match newLines
   ///

--- a/Tests/OptionsSpec.swift
+++ b/Tests/OptionsSpec.swift
@@ -28,7 +28,7 @@ final class OptionsSpec: QuickSpec {
         expect(regex.allMatches(multilineString).count).to(equal(2))
       }
     }
-	
+
 	describe(".DotMatchesLineSeparators") {
       it("allows dot to match newlines") {
 		let regex = Regex("test.test", options: .DotMatchesLineSeparators)

--- a/Tests/OptionsSpec.swift
+++ b/Tests/OptionsSpec.swift
@@ -28,6 +28,14 @@ final class OptionsSpec: QuickSpec {
         expect(regex.allMatches(multilineString).count).to(equal(2))
       }
     }
+	
+	describe(".DotMatchesLineSeparators") {
+      it("allows dot to match newlines") {
+		let regex = Regex("test.test", options: .DotMatchesLineSeparators)
+		let multilineString = "test\ntest"
+		expect(regex.allMatches(multilineString).count).to(equal(1))
+	  }
+	}
 
   }
 }


### PR DESCRIPTION
I have noticed myself quite a lot using this Regex framework for looking for paragraphs of text. One feature that I found was missing was dots match newlines. I decided to add that feature as an option for this framework.

I also updated the Quick and Nimble versions to the latest version.
