### PR TITLE
Add source compatibility with Swift 3

### DIFF
--- a/Regex.xcodeproj/project.pbxproj
+++ b/Regex.xcodeproj/project.pbxproj
@@ -7,6 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4A5986951D987E85009B35C5 /* Range+Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5986941D987E85009B35C5 /* Range+Compatibility.swift */; };
+		4A5986961D987E85009B35C5 /* Range+Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5986941D987E85009B35C5 /* Range+Compatibility.swift */; };
+		4A5986971D987E85009B35C5 /* Range+Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5986941D987E85009B35C5 /* Range+Compatibility.swift */; };
+		4A5986981D987E85009B35C5 /* Range+Compatibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5986941D987E85009B35C5 /* Range+Compatibility.swift */; };
 		4A6BF6FE1CD555880081B164 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6BF6FC1CD555880081B164 /* Nimble.framework */; };
 		4A6BF6FF1CD555880081B164 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6BF6FD1CD555880081B164 /* Quick.framework */; };
 		4A6BF7001CD555C20081B164 /* Nimble.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 4A6BF6FC1CD555880081B164 /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -126,6 +130,7 @@
 
 /* Begin PBXFileReference section */
 		05A5B69D1C5EDD3C00097E4A /* Carthage.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Carthage.xcconfig; sourceTree = "<group>"; };
+		4A5986941D987E85009B35C5 /* Range+Compatibility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Range+Compatibility.swift"; sourceTree = "<group>"; };
 		4A6BF6FC1CD555880081B164 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A6BF6FD1CD555880081B164 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4A6BF7021CD5570A0081B164 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -254,6 +259,7 @@
 				CE6CDF811BE23BE800AE6393 /* Regex.swift */,
 				CE6CDF831BE2C52600AE6393 /* MatchResult.swift */,
 				CE4BE2961C1682CF005E4D4F /* Options.swift */,
+				4A5986941D987E85009B35C5 /* Range+Compatibility.swift */,
 				CEDA44A01C45045B00B78CAF /* String+ReplaceMatching.swift */,
 				CE6CDF851BE2C64D00AE6393 /* Foundation+Ranges.swift */,
 				CE26D9ED1C34D96A003CFB54 /* ThreadLocal.swift */,
@@ -658,6 +664,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE4BE2971C1682CF005E4D4F /* Options.swift in Sources */,
+				4A5986951D987E85009B35C5 /* Range+Compatibility.swift in Sources */,
 				CE6CDF841BE2C52600AE6393 /* MatchResult.swift in Sources */,
 				CEDA44A11C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,
 				CE6CDF821BE23BE800AE6393 /* Regex.swift in Sources */,
@@ -681,6 +688,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CE4BE2981C168507005E4D4F /* Options.swift in Sources */,
+				4A5986961D987E85009B35C5 /* Range+Compatibility.swift in Sources */,
 				CEC768801BE99B690066BA1E /* Regex.swift in Sources */,
 				CEDA44A21C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,
 				CEC768811BE99B690066BA1E /* MatchResult.swift in Sources */,
@@ -704,6 +712,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CED611CB1C2A28CB008D212A /* Regex.swift in Sources */,
+				4A5986971D987E85009B35C5 /* Range+Compatibility.swift in Sources */,
 				CED611CC1C2A28CB008D212A /* MatchResult.swift in Sources */,
 				CEDA44A31C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,
 				CED611CD1C2A28CB008D212A /* Options.swift in Sources */,
@@ -717,6 +726,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				CED611ED1C2A2CC4008D212A /* Regex.swift in Sources */,
+				4A5986981D987E85009B35C5 /* Range+Compatibility.swift in Sources */,
 				CED611EE1C2A2CC4008D212A /* MatchResult.swift in Sources */,
 				CEDA44A41C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,
 				CED611EF1C2A2CC4008D212A /* Options.swift in Sources */,

--- a/Regex.xcodeproj/project.pbxproj
+++ b/Regex.xcodeproj/project.pbxproj
@@ -355,7 +355,6 @@
 				CE6CDF5C1BE239DE00AE6393 /* Frameworks */,
 				CE6CDF5D1BE239DE00AE6393 /* Headers */,
 				CE6CDF5E1BE239DE00AE6393 /* Resources */,
-				CE41D9C41C3D28EA00AE0CF8 /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -393,7 +392,6 @@
 				CEC768651BE99A040066BA1E /* Frameworks */,
 				CEC768661BE99A040066BA1E /* Headers */,
 				CEC768671BE99A040066BA1E /* Resources */,
-				CE41D9C51C3D2C7D00AE0CF8 /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -431,7 +429,6 @@
 				CED611BF1C2A281E008D212A /* Frameworks */,
 				CED611C01C2A281E008D212A /* Headers */,
 				CED611C11C2A281E008D212A /* Resources */,
-				CE41D9C61C3D2C9600AE0CF8 /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -450,7 +447,6 @@
 				CED611D21C2A2C2E008D212A /* Frameworks */,
 				CED611D31C2A2C2E008D212A /* Headers */,
 				CED611D41C2A2C2E008D212A /* Resources */,
-				CE41D9C71C3D2CB400AE0CF8 /* Swiftlint */,
 			);
 			buildRules = (
 			);
@@ -594,69 +590,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		CE41D9C41C3D28EA00AE0CF8 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env rake swiftlint";
-			showEnvVarsInLog = 0;
-		};
-		CE41D9C51C3D2C7D00AE0CF8 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env rake swiftlint";
-			showEnvVarsInLog = 0;
-		};
-		CE41D9C61C3D2C9600AE0CF8 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env rake swiftlint";
-			showEnvVarsInLog = 0;
-		};
-		CE41D9C71C3D2CB400AE0CF8 /* Swiftlint */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-			);
-			name = Swiftlint;
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "/usr/bin/env rake swiftlint";
-			showEnvVarsInLog = 0;
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		CE6CDF5B1BE239DE00AE6393 /* Sources */ = {

--- a/Source/Foundation+Ranges.swift
+++ b/Source/Foundation+Ranges.swift
@@ -1,6 +1,10 @@
 internal extension NSTextCheckingResult {
   var ranges: [NSRange] {
+#if swift(>=3.0)
+    return stride(from: 0, to: numberOfRanges, by: 1).map(rangeAt)
+#else
     return 0.stride(to: numberOfRanges, by: 1).map(rangeAtIndex)
+#endif
   }
 }
 

--- a/Source/Options.swift
+++ b/Source/Options.swift
@@ -1,5 +1,11 @@
+#if swift(>=3.0)
+private typealias _OptionSet = OptionSet
+#else
+private typealias _OptionSet = OptionSetType
+#endif
+
 /// `Options` defines alternate behaviours of regular expressions when matching.
-public struct Options: OptionSetType {
+public struct Options: _OptionSet {
 
   /// Ignores the case of letters when matching.
   ///
@@ -43,17 +49,30 @@ public struct Options: OptionSetType {
 
 }
 
+#if swift(>=3.0)
+typealias _RegularExpressionOptions = NSRegularExpression.Options
+#else
+typealias _RegularExpressionOptions = NSRegularExpressionOptions
+#endif
+
 internal extension Options {
 
   /// Transform an instance of `Regex.Options` into the equivalent `NSRegularExpressionOptions`.
   ///
   /// - returns: The equivalent `NSRegularExpressionOptions`.
-  func toNSRegularExpressionOptions() -> NSRegularExpressionOptions {
-    var options = NSRegularExpressionOptions()
+  func toNSRegularExpressionOptions() -> _RegularExpressionOptions {
+    var options = _RegularExpressionOptions()
+#if swift(>=3.0)
+    if contains(.IgnoreCase) { options.insert(.caseInsensitive) }
+    if contains(.IgnoreMetacharacters) { options.insert(.ignoreMetacharacters) }
+    if contains(.AnchorsMatchLines) { options.insert(.anchorsMatchLines) }
+    if contains(.DotMatchesLineSeparators) { options.insert(.dotMatchesLineSeparators) }
+#else
     if contains(.IgnoreCase) { options.insert(.CaseInsensitive) }
     if contains(.IgnoreMetacharacters) { options.insert(.IgnoreMetacharacters) }
     if contains(.AnchorsMatchLines) { options.insert(.AnchorsMatchLines) }
     if contains(.DotMatchesLineSeparators) { options.insert(.DotMatchesLineSeparators) }
+#endif
     return options
   }
 

--- a/Source/Range+Compatibility.swift
+++ b/Source/Range+Compatibility.swift
@@ -1,0 +1,11 @@
+#if !swift(>=3.0)
+extension Range {
+  var lowerBound: Element {
+    return startIndex
+  }
+
+  var upperBound: Element {
+    return endIndex
+  }
+}
+#endif

--- a/Source/String+ReplaceMatching.swift
+++ b/Source/String+ReplaceMatching.swift
@@ -15,6 +15,20 @@ extension String {
   /// - parameters:
   ///     - regex: A regular expression to match against `self`.
   ///     - template: A template string used to replace matches.
+#if swift(>=3.0)
+  public mutating func replaceFirstMatching(_ regex: Regex, with template: String) {
+    if let match = regex.match(self) {
+      let replacement = regex
+        .regularExpression
+        .replacementString(for: match.matchResult,
+          in: self,
+          offset: 0,
+          template: template)
+
+      replaceSubrange(match.range, with: replacement)
+    }
+  }
+#else
   public mutating func replaceFirstMatching(regex: Regex, with template: String) {
     if let match = regex.match(self) {
       let replacement = regex
@@ -27,6 +41,7 @@ extension String {
       replaceRange(match.range, with: replacement)
     }
   }
+#endif
 
   /// If the regular expression described by `pattern` matches at least one
   /// substring, replace the first match with `template`.
@@ -46,9 +61,15 @@ extension String {
   /// - parameters:
   ///     - pattern: A regular expression pattern to match against `self`.
   ///     - template: A template string used to replace matches.
+#if swift(>=3.0)
+  public mutating func replaceFirstMatching(_ pattern: StaticString, with template: String) {
+    replaceFirstMatching(Regex(pattern), with: template)
+  }
+#else
   public mutating func replaceFirstMatching(pattern: StaticString, with template: String) {
     replaceFirstMatching(Regex(pattern), with: template)
   }
+#endif
 
 
 
@@ -69,11 +90,19 @@ extension String {
   ///     - template: A template string used to replace matches.
   ///
   /// - returns: A string with the first match of `regex` replaced by `template`.
+#if swift(>=3.0)
+  public func replacingFirstMatching(_ regex: Regex, with template: String) -> String {
+    var string = self
+    string.replaceFirstMatching(regex, with: template)
+    return string
+  }
+#else
   public func replacingFirstMatching(regex: Regex, with template: String) -> String {
     var string = self
     string.replaceFirstMatching(regex, with: template)
     return string
   }
+#endif
 
   /// Returns a new string where the first match of the regular expression
   /// described by `pattern` is replaced with `template`.
@@ -95,9 +124,15 @@ extension String {
   ///     - template: A template string used to replace matches.
   ///
   /// - returns: A string with the first match of `pattern` replaced by `template`.
+#if swift(>=3.0)
+  public func replacingFirstMatching(_ pattern: StaticString, with template: String) -> String {
+    return replacingFirstMatching(Regex(pattern), with: template)
+  }
+#else
   public func replacingFirstMatching(pattern: StaticString, with template: String) -> String {
     return replacingFirstMatching(Regex(pattern), with: template)
   }
+#endif
 
 
 
@@ -115,6 +150,20 @@ extension String {
   /// - parameters:
   ///     - regex: A regular expression to match against `self`.
   ///     - template: A template string used to replace matches.
+#if swift(>=3.0)
+  public mutating func replaceAllMatching(_ regex: Regex, with template: String) {
+    for match in regex.allMatches(self).reversed() {
+      let replacement = regex
+        .regularExpression
+        .replacementString(for: match.matchResult,
+          in: self,
+          offset: 0,
+          template: template)
+
+      replaceSubrange(match.range, with: replacement)
+    }
+  }
+#else
   public mutating func replaceAllMatching(regex: Regex, with template: String) {
     for match in regex.allMatches(self).reverse() {
       let replacement = regex
@@ -127,6 +176,7 @@ extension String {
       replaceRange(match.range, with: replacement)
     }
   }
+#endif
 
   /// Replace each substring matched by the regular expression described in
   /// `pattern` with `template`.
@@ -146,9 +196,15 @@ extension String {
   /// - parameters:
   ///     - pattern: A regular expression pattern to match against `self`.
   ///     - template: A template string used to replace matches.
+#if swift(>=3.0)
+  public mutating func replaceAllMatching(_ pattern: StaticString, with template: String) {
+    replaceAllMatching(Regex(pattern), with: template)
+  }
+#else
   public mutating func replaceAllMatching(pattern: StaticString, with template: String) {
     replaceAllMatching(Regex(pattern), with: template)
   }
+#endif
 
 
 
@@ -169,11 +225,19 @@ extension String {
   ///     - template: A template string used to replace matches.
   ///
   /// - returns: A string with all matches of `regex` replaced by `template`.
+#if swift(>=3.0)
+  public func replacingAllMatching(_ regex: Regex, with template: String) -> String {
+    var string = self
+    string.replaceAllMatching(regex, with: template)
+    return string
+  }
+#else
   public func replacingAllMatching(regex: Regex, with template: String) -> String {
     var string = self
     string.replaceAllMatching(regex, with: template)
     return string
   }
+#endif
 
   /// Returns a new string where each substring matched by the regular
   /// expression described in `pattern` is replaced with `template`.
@@ -195,9 +259,15 @@ extension String {
   ///     - template: A template string used to replace matches.
   ///
   /// - returns: A string with all matches of `pattern` replaced by `template`.
+#if swift(>=3.0)
+  public func replacingAllMatching(_ pattern: StaticString, with template: String) -> String {
+    return replacingAllMatching(Regex(pattern), with: template)
+  }
+#else
   public func replacingAllMatching(pattern: StaticString, with template: String) -> String {
     return replacingAllMatching(Regex(pattern), with: template)
   }
+#endif
 
 }
 

--- a/Source/ThreadLocal.swift
+++ b/Source/ThreadLocal.swift
@@ -1,3 +1,9 @@
+#if swift(>=3.0)
+private typealias _Thread = Thread
+#else
+private typealias _Thread = NSThread
+#endif
+
 /// Convenience wrapper for generically storing values of type `T` in thread-local storage.
 internal final class ThreadLocal<T> {
 
@@ -9,16 +15,28 @@ internal final class ThreadLocal<T> {
 
   var value: T? {
     get {
+#if swift(>=3.0)
+      return _currentThread.threadDictionary[key] as? T
+#else
       guard let value = _currentThread.threadDictionary[key] else { return nil }
       return (value as? Box<T>).map { $0.value } ?? value as? T
+#endif
     }
     set {
+#if swift(>=3.0)
+      _currentThread.threadDictionary[key] = newValue
+#else
       _currentThread.threadDictionary[key] = (newValue as? AnyObject) ?? newValue.map(Box.init)
+#endif
     }
   }
 
-  private var _currentThread: NSThread {
-    return NSThread.currentThread()
+  private var _currentThread: _Thread {
+#if swift(>=3.0)
+    return _Thread.current
+#else
+    return _Thread.currentThread()
+#endif
   }
 
 }


### PR DESCRIPTION
This should add full Swift 3 support for swiftpm and CocoaPods users. Carthage users should be able to opt into Swift 3 using the `--toolchain` option to `carthage build`.

Breaking changes to drop Swift 2 support and adopt the Swift API Design Guidelines will be made in a future release.
