### PR TITLE
Linux compatibility and testing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,5 +5,9 @@ fatalError("On Linux this package requires Swift >=3.1")
 #endif
 
 let package = Package(
-  name: "Regex"
+  name: "Regex",
+  dependencies: [
+    .Package(url: "https://github.com/Quick/Quick.git", majorVersion: 1),
+    .Package(url: "https://github.com/Quick/Nimble.git", majorVersion: 5),
+  ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,9 @@
 import PackageDescription
 
+#if os(Linux) && !swift(>=3.1)
+fatalError("On Linux this package requires Swift >=3.1")
+#endif
+
 let package = Package(
   name: "Regex"
 )

--- a/Rakefile
+++ b/Rakefile
@@ -70,9 +70,14 @@ namespace :test do
   task :watchos do
     pretty "xcodebuild build -workspace Regex.xcworkspace -scheme Regex-watchOS -destination 'platform=watchOS Simulator,name=Apple Watch - 42mm'"
   end
+
+  desc "Run the SwiftPM tests"
+  task :swiftpm do
+    pretty "swift test"
+  end
 end
 
 desc "Run all tests"
-task :test => ["test:osx", "test:ios", "test:tvos", "test:watchos"]
+task :test => ["test:osx", "test:ios", "test:tvos", "test:watchos", "test:swiftpm"]
 
 task :default => :test

--- a/Source/Foundation+Ranges.swift
+++ b/Source/Foundation+Ranges.swift
@@ -1,8 +1,16 @@
 import Foundation
 
+#if os(Linux)
+typealias NSTextCheckingResult = TextCheckingResult
+#endif
+
 internal extension NSTextCheckingResult {
   var ranges: [NSRange] {
-    return stride(from: 0, to: numberOfRanges, by: 1).map(rangeAt)
+#if os(Linux)
+  return stride(from: 0, to: numberOfRanges, by: 1).map(range)
+#else
+  return stride(from: 0, to: numberOfRanges, by: 1).map(rangeAt)
+#endif
   }
 }
 

--- a/Source/Regex.swift
+++ b/Source/Regex.swift
@@ -71,7 +71,7 @@ public struct Regex: CustomStringConvertible, CustomDebugStringConvertible {
   /// - note: If the match is successful, the result is also stored in `Regex.lastMatch`.
   public func firstMatch(in string: String) -> MatchResult? {
     let match = regularExpression
-      .firstMatch(in: string, range: string.entireRange)
+      .firstMatch(in: string, options: [], range: string.entireRange)
       .map { MatchResult(string, $0) }
     Regex._lastMatch = match
     return match
@@ -88,7 +88,7 @@ public struct Regex: CustomStringConvertible, CustomDebugStringConvertible {
   /// - note: If there is at least one match, the first is stored in `Regex.lastMatch`.
   public func allMatches(in string: String) -> [MatchResult] {
     let matches = regularExpression
-      .matches(in: string, range: string.entireRange)
+      .matches(in: string, options: [], range: string.entireRange)
       .map { MatchResult(string, $0) }
     if let firstMatch = matches.first { Regex._lastMatch = firstMatch }
     return matches

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -1,0 +1,10 @@
+import XCTest
+import Quick
+
+@testable import RegexTests
+
+QCKMain([
+    RegexSpec.self,
+    OptionsSpec.self,
+    StringReplacementSpec.self,
+])


### PR DESCRIPTION
This fixed a couple issues with the library on Linux. Unfortunately, on Linux this library is only compatible with Swift version 3.1 and up.

I also enabled testing with the SwiftPM on Linux. The SwiftPM tests don't run on macOS for an unknown reason, but they don't really need to since there are other testing methods for macOS.
