### PR TITLE
Add new MatchResult.captureRanges property

### DIFF
--- a/Regex.xcodeproj/project.pbxproj
+++ b/Regex.xcodeproj/project.pbxproj
@@ -31,6 +31,10 @@
 		4A8249741EF0444A00002E42 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8249721EF0444A00002E42 /* Quick.framework */; };
 		4A8249771EF0445600002E42 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8249751EF0445600002E42 /* Nimble.framework */; };
 		4A8249781EF0445600002E42 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4A8249761EF0445600002E42 /* Quick.framework */; };
+		4AC489011F34E7AC00A84B71 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC489001F34E7AC00A84B71 /* Memo.swift */; };
+		4AC489021F34E7CC00A84B71 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC489001F34E7AC00A84B71 /* Memo.swift */; };
+		4AC489031F34E7CD00A84B71 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC489001F34E7AC00A84B71 /* Memo.swift */; };
+		4AC489041F34E7CD00A84B71 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AC489001F34E7AC00A84B71 /* Memo.swift */; };
 		CE26D9EE1C34D96A003CFB54 /* ThreadLocal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE26D9ED1C34D96A003CFB54 /* ThreadLocal.swift */; };
 		CE26D9EF1C34D96A003CFB54 /* ThreadLocal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE26D9ED1C34D96A003CFB54 /* ThreadLocal.swift */; };
 		CE26D9F01C34D96A003CFB54 /* ThreadLocal.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE26D9ED1C34D96A003CFB54 /* ThreadLocal.swift */; };
@@ -140,6 +144,7 @@
 		4A8249721EF0444A00002E42 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/Mac/Quick.framework; sourceTree = "<group>"; };
 		4A8249751EF0445600002E42 /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/tvOS/Nimble.framework; sourceTree = "<group>"; };
 		4A8249761EF0445600002E42 /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/tvOS/Quick.framework; sourceTree = "<group>"; };
+		4AC489001F34E7AC00A84B71 /* Memo.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
 		CE26D9ED1C34D96A003CFB54 /* ThreadLocal.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThreadLocal.swift; sourceTree = "<group>"; };
 		CE4BE2961C1682CF005E4D4F /* Options.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Options.swift; sourceTree = "<group>"; };
 		CE6CDF601BE239DE00AE6393 /* Regex.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Regex.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -282,6 +287,7 @@
 			children = (
 				CE6CDF811BE23BE800AE6393 /* Regex.swift */,
 				CE6CDF831BE2C52600AE6393 /* MatchResult.swift */,
+				4AC489001F34E7AC00A84B71 /* Memo.swift */,
 				CE4BE2961C1682CF005E4D4F /* Options.swift */,
 				CEDA44A01C45045B00B78CAF /* String+ReplaceMatching.swift */,
 				CE6CDF851BE2C64D00AE6393 /* Foundation+Ranges.swift */,
@@ -604,6 +610,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AC489011F34E7AC00A84B71 /* Memo.swift in Sources */,
 				CE4BE2971C1682CF005E4D4F /* Options.swift in Sources */,
 				CE6CDF841BE2C52600AE6393 /* MatchResult.swift in Sources */,
 				CEDA44A11C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,
@@ -628,6 +635,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AC489021F34E7CC00A84B71 /* Memo.swift in Sources */,
 				CE4BE2981C168507005E4D4F /* Options.swift in Sources */,
 				CEC768801BE99B690066BA1E /* Regex.swift in Sources */,
 				CEDA44A21C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,
@@ -652,6 +660,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AC489031F34E7CD00A84B71 /* Memo.swift in Sources */,
 				CED611CB1C2A28CB008D212A /* Regex.swift in Sources */,
 				CED611CC1C2A28CB008D212A /* MatchResult.swift in Sources */,
 				CEDA44A31C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,
@@ -665,6 +674,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				4AC489041F34E7CD00A84B71 /* Memo.swift in Sources */,
 				CED611ED1C2A2CC4008D212A /* Regex.swift in Sources */,
 				CED611EE1C2A2CC4008D212A /* MatchResult.swift in Sources */,
 				CEDA44A41C45045B00B78CAF /* String+ReplaceMatching.swift in Sources */,

--- a/Source/Memo.swift
+++ b/Source/Memo.swift
@@ -1,0 +1,71 @@
+// Copyright (c) 2014 Rob Rix. All rights reserved.
+//
+// Source: https://github.com/robrix/Memo/blob/326153487940ab19c1d25761656269e25fbbf119/Memo/Memo.swift
+
+/// Deferred, memoized evaluation.
+internal struct Memo<T> {
+  // MARK: Lifecycle
+
+  /// Constructs a `Memo` which lazily evaluates the argument.
+  init(_ unevaluated:  @escaping () -> T) {
+    self.init(unevaluated: unevaluated)
+  }
+
+  /// Constructs a `Memo` which lazily evaluates the passed function.
+  init(unevaluated: @escaping () -> T) {
+    self.init(state: .unevaluated(unevaluated))
+  }
+
+  /// Constructs a `Memo` wrapping the already-evaluated argument.
+  init(evaluated: T) {
+    self.init(state: .evaluated(evaluated))
+  }
+
+  // MARK: Properties
+
+  /// Returns the value held by the receiver, computing & memoizing it first if necessary.
+  var value: T {
+    return state.value.value()
+  }
+
+  // MARK: Private
+
+  /// Initialize with the passed `state`.
+  private init(state: MemoState<T>) {
+    self.state = MutableBox(state)
+  }
+
+  /// The underlying state.
+  ///
+  /// The `enum` implements the basic semantics (either evaluated or un), while the `MutableBox` provides us with reference semantics for the memoized result.
+  private let state: MutableBox<MemoState<T>>
+}
+
+// MARK: Private
+
+/// Private state for memoization.
+private enum MemoState<T> {
+  case evaluated(T)
+  case unevaluated(() -> T)
+
+  /// Return the value, computing and memoizing it first if necessary.
+  mutating func value() -> T {
+    switch self {
+    case let .evaluated(x):
+      return x
+    case let .unevaluated(f):
+      let value = f()
+      self = .evaluated(value)
+      return value
+    }
+  }
+}
+
+/// A mutable reference type boxing a value.
+private final class MutableBox<T> {
+  init(_ value: T) {
+    self.value = value
+  }
+
+  var value: T
+}

--- a/Source/Memo.swift
+++ b/Source/Memo.swift
@@ -37,7 +37,9 @@ internal struct Memo<T> {
 
   /// The underlying state.
   ///
-  /// The `enum` implements the basic semantics (either evaluated or un), while the `MutableBox` provides us with reference semantics for the memoized result.
+  /// The `enum` implements the basic semantics (either evaluated or un),
+  /// while the `MutableBox` provides us with reference semantics for the
+  /// memoized result.
   private let state: MutableBox<MemoState<T>>
 }
 

--- a/Tests/RegexTests/RegexSpec.swift
+++ b/Tests/RegexTests/RegexSpec.swift
@@ -61,6 +61,21 @@ final class RegexSpec: QuickSpec {
 
         expect(matched).to(beTrue())
       }
+
+      it("provides access to the matched range") {
+        let foobar = "foobar"
+        let match = Regex("f(oo)").firstMatch(in: foobar)!
+        expect(foobar[match.range]) == "foo"
+      }
+
+      it("provides access to capture ranges") {
+        let foobar = "foobar"
+        let match = Regex("f(oo)b(ar)").firstMatch(in: foobar)!
+        let firstCaptureRange = match.captureRanges[0]!
+        let secondCaptureRange = match.captureRanges[1]!
+        expect(foobar[firstCaptureRange]) == "oo"
+        expect(foobar[secondCaptureRange]) == "ar"
+      }
     }
 
     describe("optional capture groups") {


### PR DESCRIPTION
Just found an old branch where I'd been intending to make `MatchResult.range` public (now taken care of by #54).

This change adds a complementary `captureRanges` property, and adds an internal `Memo` helper to avoid doing range conversions every time the property is accessed. It should be safe to keep accessing the array in constant time.