### PR TITLE
Add a Swift 4–specific package manifest

### DIFF
--- a/Package@swift-4.swift
+++ b/Package@swift-4.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:4.0
+
+import PackageDescription
+
+let package = Package(
+  name: "Regex",
+  products: [
+    .library(name: "Regex", targets: ["Regex"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/Quick/Quick.git", from: "1.1.0"),
+    .package(url: "https://github.com/Quick/Nimble.git", from: "7.0.1"),
+  ],
+  targets: [
+    .target(name: "Regex", dependencies: [], path: "Source"),
+    .testTarget(name: "RegexTests", dependencies: [
+      "Nimble",
+      "Quick",
+      "Regex",
+    ]),
+  ],
+  swiftLanguageVersions: [3, 4]
+)


### PR DESCRIPTION
Once Swift 4 is released, this should become the default `Package.swift`, and the existing manifest renamed to `Package@swift-3.swift`.